### PR TITLE
Allow messages to be larger than required size

### DIFF
--- a/src/dsp/bios.c
+++ b/src/dsp/bios.c
@@ -288,7 +288,7 @@ int decode_get_bios_table_req(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_GET_BIOS_TABLE_REQ_BYTES) {
+	if (payload_length < PLDM_GET_BIOS_TABLE_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 

--- a/src/dsp/fru.c
+++ b/src/dsp/fru.c
@@ -18,7 +18,7 @@ int encode_get_fru_record_table_metadata_req(uint8_t instance_id,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_GET_FRU_RECORD_TABLE_METADATA_REQ_BYTES) {
+	if (payload_length < PLDM_GET_FRU_RECORD_TABLE_METADATA_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -52,7 +52,7 @@ int decode_get_fru_record_table_metadata_resp(
 		return PLDM_SUCCESS;
 	}
 
-	if (payload_length != PLDM_GET_FRU_RECORD_TABLE_METADATA_RESP_BYTES) {
+	if (payload_length < PLDM_GET_FRU_RECORD_TABLE_METADATA_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -123,7 +123,7 @@ int decode_get_fru_record_table_req(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_GET_FRU_RECORD_TABLE_REQ_BYTES) {
+	if (payload_length < PLDM_GET_FRU_RECORD_TABLE_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -303,7 +303,7 @@ int encode_get_fru_record_by_option_req(
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length !=
+	if (payload_length <
 	    sizeof(struct pldm_get_fru_record_by_option_req)) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
@@ -345,7 +345,7 @@ int decode_get_fru_record_by_option_req(
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length !=
+	if (payload_length <
 	    sizeof(struct pldm_get_fru_record_by_option_req)) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
@@ -451,7 +451,7 @@ int encode_get_fru_record_table_req(uint8_t instance_id,
 	if (msg == NULL) {
 		return PLDM_ERROR_INVALID_DATA;
 	}
-	if (payload_length != sizeof(struct pldm_get_fru_record_table_req)) {
+	if (payload_length < sizeof(struct pldm_get_fru_record_table_req)) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -568,7 +568,7 @@ int encode_set_fru_record_table_resp(uint8_t instance_id,
 	if (msg == NULL) {
 		return PLDM_ERROR_INVALID_DATA;
 	}
-	if (payload_length != PLDM_SET_FRU_RECORD_TABLE_RESP_BYTES) {
+	if (payload_length < PLDM_SET_FRU_RECORD_TABLE_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 

--- a/src/oem/ibm/file_io.c
+++ b/src/oem/ibm/file_io.c
@@ -15,7 +15,7 @@ int decode_rw_file_memory_req(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_RW_FILE_MEM_REQ_BYTES) {
+	if (payload_length < PLDM_RW_FILE_MEM_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -97,7 +97,7 @@ int decode_rw_file_memory_resp(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_RW_FILE_MEM_RESP_BYTES) {
+	if (payload_length < PLDM_RW_FILE_MEM_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -121,7 +121,7 @@ int decode_get_file_table_req(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_GET_FILE_TABLE_REQ_BYTES) {
+	if (payload_length < PLDM_GET_FILE_TABLE_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -245,7 +245,7 @@ int decode_read_file_req(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_READ_FILE_REQ_BYTES) {
+	if (payload_length < PLDM_READ_FILE_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -417,7 +417,7 @@ int decode_write_file_resp(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_WRITE_FILE_RESP_BYTES) {
+	if (payload_length < PLDM_WRITE_FILE_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -473,7 +473,7 @@ int decode_rw_file_by_type_memory_req(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_RW_FILE_BY_TYPE_MEM_REQ_BYTES) {
+	if (payload_length < PLDM_RW_FILE_BY_TYPE_MEM_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -558,7 +558,7 @@ int decode_rw_file_by_type_memory_resp(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_RW_FILE_BY_TYPE_MEM_RESP_BYTES) {
+	if (payload_length < PLDM_RW_FILE_BY_TYPE_MEM_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -582,7 +582,7 @@ int decode_new_file_req(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_NEW_FILE_REQ_BYTES) {
+	if (payload_length < PLDM_NEW_FILE_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -656,7 +656,7 @@ int decode_new_file_resp(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_NEW_FILE_RESP_BYTES) {
+	if (payload_length < PLDM_NEW_FILE_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -768,7 +768,7 @@ int decode_rw_file_by_type_resp(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_RW_FILE_BY_TYPE_RESP_BYTES) {
+	if (payload_length < PLDM_RW_FILE_BY_TYPE_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -791,7 +791,7 @@ int decode_file_ack_req(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_FILE_ACK_REQ_BYTES) {
+	if (payload_length < PLDM_FILE_ACK_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -865,7 +865,7 @@ int decode_file_ack_resp(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_FILE_ACK_RESP_BYTES) {
+	if (payload_length < PLDM_FILE_ACK_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -919,7 +919,7 @@ int decode_file_ack_with_meta_data_resp(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_FILE_ACK_WITH_META_DATA_RESP_BYTES) {
+	if (payload_length < PLDM_FILE_ACK_WITH_META_DATA_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -941,7 +941,7 @@ int decode_file_ack_with_meta_data_req(
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_FILE_ACK_WITH_META_DATA_REQ_BYTES) {
+	if (payload_length < PLDM_FILE_ACK_WITH_META_DATA_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -1029,7 +1029,7 @@ int decode_new_file_with_metadata_resp(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length !=
+	if (payload_length <
 	    PLDM_NEW_FILE_AVAILABLE_WITH_META_DATA_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
@@ -1056,7 +1056,7 @@ int decode_new_file_with_metadata_req(
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length !=
+	if (payload_length <
 	    PLDM_NEW_FILE_AVAILABLE_WITH_META_DATA_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}

--- a/src/oem/ibm/host.c
+++ b/src/oem/ibm/host.c
@@ -14,7 +14,7 @@ int encode_get_alert_status_req(uint8_t instance_id, uint8_t version_id,
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
-	if (payload_length != PLDM_GET_ALERT_STATUS_REQ_BYTES) {
+	if (payload_length < PLDM_GET_ALERT_STATUS_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -49,7 +49,7 @@ int decode_get_alert_status_resp(const struct pldm_msg *msg,
 		return PLDM_SUCCESS;
 	}
 
-	if (payload_length != PLDM_GET_ALERT_STATUS_RESP_BYTES) {
+	if (payload_length < PLDM_GET_ALERT_STATUS_RESP_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -70,7 +70,7 @@ int decode_get_alert_status_req(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_GET_ALERT_STATUS_REQ_BYTES) {
+	if (payload_length < PLDM_GET_ALERT_STATUS_REQ_BYTES) {
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
@@ -85,11 +85,11 @@ int encode_get_alert_status_resp(uint8_t instance_id, uint8_t completion_code,
 				 struct pldm_msg *msg, size_t payload_length)
 {
 	if (msg == NULL) {
-		return PLDM_ERROR_INVALID_LENGTH;
+		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (payload_length != PLDM_GET_ALERT_STATUS_RESP_BYTES) {
-		return PLDM_ERROR_INVALID_DATA;
+	if (payload_length < PLDM_GET_ALERT_STATUS_RESP_BYTES) {
+		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
 	struct pldm_header_info header = { 0 };


### PR DESCRIPTION
In many cases a message contains variable-length data.  The decode/encode functions should allow callers to pass in the complete message rather than having to understand the details of the message structures that the decode/encode functions are attempting to abstract.

The change here is simply to allow any input buffer that is at least as big as the message size requires.