### PR TITLE
Check invalid comp_comparison_stamp

### DIFF
--- a/src/dsp/firmware_update.c
+++ b/src/dsp/firmware_update.c
@@ -640,8 +640,8 @@ int decode_pldm_comp_image_info(
 	pldm_comp_image_info->comp_version_string_length =
 		data_header->comp_version_string_length;
 
-	if ((pldm_comp_image_info->comp_options.bits.bit1 == false &&
-	     pldm_comp_image_info->comp_comparison_stamp !=
+	if ((pldm_comp_image_info->comp_options.bits.bit1 == true &&
+	     pldm_comp_image_info->comp_comparison_stamp ==
 		     PLDM_FWUP_INVALID_COMPONENT_COMPARISON_TIMESTAMP)) {
 		return PLDM_ERROR_INVALID_DATA;
 	}


### PR DESCRIPTION
When use component comparison stamp, the stamp shall not be invalid.