### PR TITLE
libpldm: consistently prefix include guard with LIBPLDM

### DIFF
--- a/include/libpldm/base.h
+++ b/include/libpldm/base.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef BASE_H
-#define BASE_H
+#ifndef LIBPLDM_BASE_H
+#define LIBPLDM_BASE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -873,4 +873,4 @@ int decode_pldm_base_negotiate_transfer_params_resp(
 }
 #endif
 
-#endif /* BASE_H */
+#endif /* LIBPLDM_BASE_H */

--- a/include/libpldm/bios.h
+++ b/include/libpldm/bios.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef BIOS_H
-#define BIOS_H
+#ifndef LIBPLDM_BIOS_H
+#define LIBPLDM_BIOS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -618,4 +618,4 @@ int decode_set_bios_table_req(const struct pldm_msg *msg, size_t payload_length,
 }
 #endif
 
-#endif /* BIOS_H */
+#endif /* LIBPLDM_BIOS_H */

--- a/include/libpldm/entity.h
+++ b/include/libpldm/entity.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef ENTITY_H
-#define ENTITY_H
+#ifndef LIBPLDM_ENTITY_H
+#define LIBPLDM_ENTITY_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -183,4 +183,4 @@ enum pldm_entity_id_codes {
 }
 #endif
 
-#endif /* ENTITY_H */
+#endif /* LIBPLDM_ENTITY_H */

--- a/include/libpldm/firmware_update.h
+++ b/include/libpldm/firmware_update.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef FW_UPDATE_H
-#define FW_UPDATE_H
+#ifndef LIBPLDM_FW_UPDATE_H
+#define LIBPLDM_FW_UPDATE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -3034,4 +3034,4 @@ int decode_pldm_package_component_image_information_from_iter(
 }
 #endif
 
-#endif // End of FW_UPDATE_H
+#endif // End of LIBPLDM_FW_UPDATE_H

--- a/include/libpldm/fru.h
+++ b/include/libpldm/fru.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef FRU_H
-#define FRU_H
+#ifndef LIBPLDM_FRU_H
+#define LIBPLDM_FRU_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/libpldm/instance-id.h
+++ b/include/libpldm/instance-id.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef INSTANCE_ID_H
-#define INSTANCE_ID_H
+#ifndef LIBPLDM_INSTANCE_ID_H
+#define LIBPLDM_INSTANCE_ID_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -91,4 +91,4 @@ int pldm_instance_id_free(struct pldm_instance_db *ctx, pldm_tid_t tid,
 }
 #endif
 
-#endif /* INSTANCE_ID_H */
+#endif /* LIBPLDM_INSTANCE_ID_H */

--- a/include/libpldm/oem/ibm/entity.h
+++ b/include/libpldm/oem/ibm/entity.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef OEM_IBM_ENTITY_H
-#define OEM_IBM_ENTITY_H
+#ifndef LIBPLDM_OEM_IBM_ENTITY_H
+#define LIBPLDM_OEM_IBM_ENTITY_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,4 +16,4 @@ enum pldm_oem_ibm_entity_id_codes {
 }
 #endif
 
-#endif /* OEM_IBM_ENTITY_H */
+#endif /* LIBPLDM_OEM_IBM_ENTITY_H */

--- a/include/libpldm/oem/ibm/file_io.h
+++ b/include/libpldm/oem/ibm/file_io.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef FILEIO_H
-#define FILEIO_H
+#ifndef LIBPLDM_FILEIO_H
+#define LIBPLDM_FILEIO_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -917,4 +917,4 @@ int encode_new_file_with_metadata_resp(uint8_t instance_id,
 }
 #endif
 
-#endif /* FILEIO_H */
+#endif /* LIBPLDM_FILEIO_H */

--- a/include/libpldm/oem/ibm/fru.h
+++ b/include/libpldm/oem/ibm/fru.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef OEM_IBM_FRU_H
-#define OEM_IBM_FRU_H
+#ifndef LIBPLDM_OEM_IBM_FRU_H
+#define LIBPLDM_OEM_IBM_FRU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,4 +26,4 @@ enum pldm_oem_ibm_fru_field_type {
 }
 #endif
 
-#endif /* OEM_IBM_FRU_H */
+#endif /* LIBPLDM_OEM_IBM_FRU_H */

--- a/include/libpldm/oem/ibm/host.h
+++ b/include/libpldm/oem/ibm/host.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef OEM_IBM_HOST_H
-#define OEM_IBM_HOST_H
+#ifndef LIBPLDM_OEM_IBM_HOST_H
+#define LIBPLDM_OEM_IBM_HOST_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -106,4 +106,4 @@ int encode_get_alert_status_resp(uint8_t instance_id, uint8_t completion_code,
 }
 #endif
 
-#endif /* OEM_IBM_HOST_H */
+#endif /* LIBPLDM_OEM_IBM_HOST_H */

--- a/include/libpldm/oem/ibm/platform.h
+++ b/include/libpldm/oem/ibm/platform.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef PLATFORM_OEM_IBM_H
-#define PLATFORM_OEM_IBM_H
+#ifndef LIBPLDM_PLATFORM_OEM_IBM_H
+#define LIBPLDM_PLATFORM_OEM_IBM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,4 +55,4 @@ int encode_bios_attribute_update_event_req(uint8_t instance_id,
 }
 #endif
 
-#endif /* PLATFORM_OEM_IBM_H */
+#endif /* LIBPLDM_PLATFORM_OEM_IBM_H */

--- a/include/libpldm/oem/ibm/state_set.h
+++ b/include/libpldm/oem/ibm/state_set.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef STATE_SET_OEM_IBM_H
-#define STATE_SET_OEM_IBM_H
+#ifndef LIBPLDM_STATE_SET_OEM_IBM_H
+#define LIBPLDM_STATE_SET_OEM_IBM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,4 +85,4 @@ enum pldm_oem_ibm_boot_side_rename_state {
 }
 #endif
 
-#endif /* STATE_SET_OEM_IBM_H */
+#endif /* LIBPLDM_STATE_SET_OEM_IBM_H */

--- a/include/libpldm/pdr.h
+++ b/include/libpldm/pdr.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef PDR_H
-#define PDR_H
+#ifndef LIBPLDM_PDR_H
+#define LIBPLDM_PDR_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -725,4 +725,4 @@ int pldm_pdr_remove_fru_record_set_by_rsi(pldm_pdr *repo, uint16_t fru_rsi,
 }
 #endif
 
-#endif /* PDR_H */
+#endif /* LIBPLDM_PDR_H */

--- a/include/libpldm/platform.h
+++ b/include/libpldm/platform.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef PLATFORM_H
-#define PLATFORM_H
+#ifndef LIBPLDM_PLATFORM_H
+#define LIBPLDM_PLATFORM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -2778,4 +2778,4 @@ int decode_set_state_sensor_enables_req(
 }
 #endif
 
-#endif /* PLATFORM_H */
+#endif /* LIBPLDM_PLATFORM_H */

--- a/include/libpldm/pldm.h
+++ b/include/libpldm/pldm.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef MCTP_H
-#define MCTP_H
+#ifndef LIBPLDM_MCTP_H
+#define LIBPLDM_MCTP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,4 +33,4 @@ typedef enum pldm_requester_error_codes {
 }
 #endif
 
-#endif /* MCTP_H */
+#endif /* LIBPLDM_MCTP_H */

--- a/include/libpldm/pldm_types.h
+++ b/include/libpldm/pldm_types.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef PLDM_TYPES_H
-#define PLDM_TYPES_H
+#ifndef LIBPLDM_PLDM_TYPES_H
+#define LIBPLDM_PLDM_TYPES_H
 
 #ifdef __cplusplus
 #include <cstdint>
@@ -169,4 +169,4 @@ typedef float real32_t;
 
 typedef uint8_t pldm_uuid[16];
 
-#endif /* PLDM_TYPES_H */
+#endif /* LIBPLDM_PLDM_TYPES_H */

--- a/include/libpldm/state_set.h
+++ b/include/libpldm/state_set.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef STATE_SET_H
-#define STATE_SET_H
+#ifndef LIBPLDM_STATE_SET_H
+#define LIBPLDM_STATE_SET_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -277,4 +277,4 @@ enum pldm_state_set_device_power_state_values {
 }
 #endif
 
-#endif /* STATE_SET_H */
+#endif /* LIBPLDM_STATE_SET_H */

--- a/include/libpldm/states.h
+++ b/include/libpldm/states.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef STATES_H
-#define STATES_H
+#ifndef LIBPLDM_STATES_H
+#define LIBPLDM_STATES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,4 +25,4 @@ enum pldm_system_power_states {
 }
 #endif
 
-#endif /* STATES_H */
+#endif /* LIBPLDM_STATES_H */

--- a/include/libpldm/transport.h
+++ b/include/libpldm/transport.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
-#ifndef TRANSPORT_PLDM_H
-#define TRANSPORT_PLDM_H
+#ifndef LIBPLDM_TRANSPORT_PLDM_H
+#define LIBPLDM_TRANSPORT_PLDM_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/libpldm/transport/af-mctp.h
+++ b/include/libpldm/transport/af-mctp.h
@@ -58,4 +58,4 @@ int pldm_transport_af_mctp_bind(struct pldm_transport_af_mctp *transport,
 }
 #endif
 
-#endif /* LIBPLDM_AF_MCTP*/
+#endif /* LIBPLDM_AF_MCTP_H */


### PR DESCRIPTION
Some include guards are very generic, e.g. BASE_H, which can clash with headers from other projects included in the same code.  This makes sure include guards are consistently guarded with a LIBPLDM prefix, which should be unique enough.