### PR TITLE
tests: Fix DecodeGetStateSensorReadings.PayloadTooShort expected error code

### DIFF
--- a/tests/dsp/platform.cpp
+++ b/tests/dsp/platform.cpp
@@ -6621,3 +6621,39 @@ TEST(EncodePldmFileDescriptorPdr, BadParamBufferTooSmall)
               -EOVERFLOW);
 }
 #endif
+TEST(EncodeGetStateSensorReadings, InvalidNullMsg)
+{
+    bitfield8_t rearm = {0};
+    uint8_t reserved = 0;
+    auto rc = encode_get_state_sensor_readings_req(0, 0x1234, rearm, reserved, nullptr);
+
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+}
+
+TEST(DecodeGetStateSensorReadings, NullCompletionCode)
+{
+    std::array<uint8_t, sizeof(pldm_msg_hdr) + 3> msg{};
+    auto response = reinterpret_cast<pldm_msg*>(msg.data());
+    response->payload[0] = PLDM_SUCCESS;
+    response->payload[1] = 1; // comp_sensor_count
+
+    auto rc = decode_get_state_sensor_readings_resp(
+        response, msg.size() - sizeof(pldm_msg_hdr),
+        nullptr, nullptr, nullptr);
+
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+}
+
+TEST(DecodeGetStateSensorReadings, PayloadTooShort)
+{
+    std::array<uint8_t, sizeof(pldm_msg_hdr) + 1> msg{};
+    auto response = reinterpret_cast<pldm_msg*>(msg.data());
+
+    uint8_t cc = 0;
+    uint8_t count = 0;
+    auto rc = decode_get_state_sensor_readings_resp(
+        response, msg.size() - sizeof(pldm_msg_hdr),
+        &cc, &count, nullptr);
+
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+}


### PR DESCRIPTION

Corrected expected error constant from PLDM_ERROR_INVALID_LENGTH to PLDM_ERROR_INVALID_DATA,
aligning test with actual function behavior.
